### PR TITLE
Update path of ipython_magics for latest aiida

### DIFF
--- a/files/ipython_config.py
+++ b/files/ipython_config.py
@@ -1,4 +1,4 @@
 c = get_config()
 c.InteractiveShellApp.extensions = [
-  'aiida.common.ipython.ipython_magics'
+  'aiida.tools.ipython.ipython_magics'
 ]


### PR DESCRIPTION
This re-enables %aiida and removes warnings in the verdi shell.