### PR TITLE
Do not clone submodules when cloning apps.

### DIFF
--- a/tasks/apps.yml
+++ b/tasks/apps.yml
@@ -5,4 +5,6 @@
     dest: "{{ aiidalab_apps_folder }}/{{ item.name }}"
     force: true
     version: "{{ item.version }}"
+    accept_hostkey: True
+    recursive: False
   with_items: "{{ aiidalab_apps }}"


### PR DESCRIPTION
App aiidalab-qe has 3 submodules that ansible tries to clone
("recursive" is True by default). However, cloning them requires either
a deploy key, or the credentials of an account that can access all
the submodule repos via SSH. Since, according to Sasha, none of the
submodules of aiidalab-qe are actually required here, we simply
disable recursive cloning. No other app has submodules at the moment,
but future apps might: in that case the "recursive" flag could
become a per-item property.

Tested on one AWS instance.